### PR TITLE
Return entry when s3 is not available

### DIFF
--- a/frcGformsS3Upload.php
+++ b/frcGformsS3Upload.php
@@ -459,7 +459,7 @@ class FrcGformsS3Upload {
 
         $as3cf = $this->getAs3cfInstance();
         if (is_null($as3cf)) {
-            return false;
+            return $entry;
         }
 
         $files       = GFCommon::json_decode(stripslashes(GFForms::post('gform_uploaded_files')));


### PR DESCRIPTION
The ` add_filter('gform_entry_post_save', [$this, 'entryPostSaveAws'], 5, 2);` should return the `$entry`.